### PR TITLE
Update behavior of out of sync subgraphs

### DIFF
--- a/proxy-api/package-lock.json
+++ b/proxy-api/package-lock.json
@@ -2060,9 +2060,9 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
@@ -4792,9 +4792,9 @@
       "dev": true
     },
     "node_modules/path-to-regexp": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
-      "integrity": "sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw=="
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="
     },
     "node_modules/picocolors": {
       "version": "1.0.1",
@@ -7182,9 +7182,9 @@
       }
     },
     "cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "requires": {
         "path-key": "^3.1.0",
@@ -9162,9 +9162,9 @@
       "dev": true
     },
     "path-to-regexp": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
-      "integrity": "sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw=="
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="
     },
     "picocolors": {
       "version": "1.0.1",

--- a/proxy-api/src/services/subgraph-proxy-service.js
+++ b/proxy-api/src/services/subgraph-proxy-service.js
@@ -221,6 +221,7 @@ class SubgraphProxyService {
         throw new RequestError(errors[0].message);
       }
     } else if (unsyncdEndpoints.length > 0) {
+      DiscordUtil.sendWebhookMessage(`Subgraph ${subgraphName} has fallen behind.`);
       throw new EndpointError('Subgraph has not yet indexed up to the latest block.');
     }
   }

--- a/proxy-api/src/services/subgraph-proxy-service.js
+++ b/proxy-api/src/services/subgraph-proxy-service.js
@@ -74,7 +74,7 @@ class SubgraphProxyService {
     subgraphName,
     query,
     variables,
-    minBlock,
+    minIndexedBlock,
     failedEndpoints,
     unsyncdEndpoints,
     staleVersionEndpoints,
@@ -118,7 +118,7 @@ class SubgraphProxyService {
         // Avoid endpoints that are out of sync unless it is explicitly allowable
         if (
           !EnvUtil.allowUnsyncd() &&
-          queryResult._meta.block.number < minBlock &&
+          queryResult._meta.block.number < minIndexedBlock &&
           !(await SubgraphState.isInSync(endpointIndex, subgraphName))
         ) {
           unsyncdEndpoints.push(endpointIndex);

--- a/proxy-api/src/utils/graph-query.js
+++ b/proxy-api/src/utils/graph-query.js
@@ -43,6 +43,14 @@ class GraphqlQueryUtil {
     return result;
   }
 
+  // Returns the minimum block that must be indexed for this query to be responded to.
+  // Currently considers introspection only.
+  // Future work includes analyzing individual requested entities and whether they have a block number provided.
+  static minNeededBlock(originalQuery) {
+    // TODO:
+    return 99999999990;
+  }
+
   static _includesMeta(originalQuery) {
     return /_meta\s*\{/.test(originalQuery);
   }

--- a/proxy-api/src/utils/graph-query.js
+++ b/proxy-api/src/utils/graph-query.js
@@ -47,8 +47,12 @@ class GraphqlQueryUtil {
   // Currently considers introspection only.
   // Future work includes analyzing individual requested entities and whether they have a block number provided.
   static minNeededBlock(originalQuery) {
-    // TODO:
-    return 99999999990;
+    const introspectionRegex = /\s*(?:__schema|__type)\s*{/;
+    if (introspectionRegex.test(originalQuery)) {
+      // Always respond to an introspection request regardless of indexing progress
+      return 0;
+    }
+    return Number.MAX_SAFE_INTEGER;
   }
 
   static _includesMeta(originalQuery) {

--- a/proxy-api/test/proxy-internals.test.js
+++ b/proxy-api/test/proxy-internals.test.js
@@ -21,7 +21,7 @@ const newDeploymentBlock = beanNewDeploymentResponse._meta.block.number;
 
 // For capturing arguments to EndpointBalanceUtil.chooseEndpoint
 let endpointArgCapture;
-const _getQueryResult = (minBlock = 9999999999) =>
+const _getQueryResult = (minBlock = Number.MAX_SAFE_INTEGER) =>
   SubgraphProxyService._getQueryResult('bean', 'graphql query', undefined, minBlock);
 
 describe('Subgraph Proxy - Core', () => {

--- a/proxy-api/test/proxy-internals.test.js
+++ b/proxy-api/test/proxy-internals.test.js
@@ -21,6 +21,7 @@ const newDeploymentBlock = beanNewDeploymentResponse._meta.block.number;
 
 // For capturing arguments to EndpointBalanceUtil.chooseEndpoint
 let endpointArgCapture;
+const _getQueryResult = () => SubgraphProxyService._getQueryResult('bean', 'graphql query', undefined, 9999999999);
 
 describe('Subgraph Proxy - Core', () => {
   beforeEach(() => {
@@ -72,7 +73,7 @@ describe('Subgraph Proxy - Core', () => {
 
     test('Initial endpoint succeeds', async () => {
       jest.spyOn(SubgraphClients, 'makeCallableClient').mockResolvedValueOnce(async () => beanResponse);
-      await expect(SubgraphProxyService._getQueryResult('bean', 'graphql query')).resolves.not.toThrow();
+      await expect(_getQueryResult()).resolves.not.toThrow();
 
       expect(EndpointBalanceUtil.chooseEndpoint).toHaveBeenCalledTimes(1);
       expect(endpointArgCapture[0]).toEqual(['bean', [], [], null]);
@@ -85,7 +86,7 @@ describe('Subgraph Proxy - Core', () => {
         })
         .mockResolvedValueOnce(async () => beanResponse);
 
-      await expect(SubgraphProxyService._getQueryResult('bean', 'graphql query')).resolves.not.toThrow();
+      await expect(_getQueryResult()).resolves.not.toThrow();
 
       expect(EndpointBalanceUtil.chooseEndpoint).toHaveBeenCalledTimes(2);
       expect(endpointArgCapture[0]).toEqual(['bean', [], [], null]);
@@ -102,7 +103,7 @@ describe('Subgraph Proxy - Core', () => {
         });
       jest.spyOn(SubgraphStatusService, 'checkFatalError').mockResolvedValue(undefined);
 
-      await expect(SubgraphProxyService._getQueryResult('bean', 'graphql query')).rejects.toThrow(RequestError);
+      await expect(_getQueryResult()).rejects.toThrow(RequestError);
       expect(EndpointBalanceUtil.chooseEndpoint).toHaveBeenCalledTimes(4);
       expect(endpointArgCapture[0]).toEqual(['bean', [], [], null]);
       expect(endpointArgCapture[1]).toEqual(['bean', [0], [0], null]);
@@ -128,7 +129,7 @@ describe('Subgraph Proxy - Core', () => {
         .mockResolvedValueOnce(async () => beanNewDeploymentResponse)
         .mockResolvedValueOnce(async () => beanResponse);
 
-      await expect(SubgraphProxyService._getQueryResult('bean', 'graphql query')).resolves.not.toThrow();
+      await expect(_getQueryResult()).resolves.not.toThrow();
 
       expect(EndpointBalanceUtil.chooseEndpoint).toHaveBeenCalledTimes(2);
       expect(endpointArgCapture[1]).toEqual(['bean', [0], [0], null]);
@@ -139,7 +140,7 @@ describe('Subgraph Proxy - Core', () => {
         .mockResolvedValueOnce(async () => beanNewDeploymentResponse)
         .mockResolvedValueOnce(async () => beanNewDeploymentResponse);
 
-      await expect(SubgraphProxyService._getQueryResult('bean', 'graphql query')).rejects.toThrow(EndpointError);
+      await expect(_getQueryResult()).rejects.toThrow(EndpointError);
 
       expect(EndpointBalanceUtil.chooseEndpoint).toHaveBeenCalledTimes(3);
       expect(endpointArgCapture[1]).toEqual(['bean', [0], [0], null]);
@@ -166,7 +167,7 @@ describe('Subgraph Proxy - Core', () => {
           })
           .mockResolvedValueOnce(async () => beanOldVersionResponse);
 
-        await expect(SubgraphProxyService._getQueryResult('bean', 'graphql query')).resolves.not.toThrow();
+        await expect(_getQueryResult()).resolves.not.toThrow();
         expect(EndpointBalanceUtil.chooseEndpoint).toHaveBeenCalledTimes(3);
         expect(endpointArgCapture[1]).toEqual(['bean', [0], [0], null]);
         expect(endpointArgCapture[2]).toEqual(['bean', [1], [0, 1], null]);
@@ -178,7 +179,7 @@ describe('Subgraph Proxy - Core', () => {
           .mockResolvedValueOnce(async () => beanFarBehindResponse)
           .mockResolvedValueOnce(async () => beanOldVersionResponse);
 
-        await expect(SubgraphProxyService._getQueryResult('bean', 'graphql query')).resolves.not.toThrow();
+        await expect(_getQueryResult()).resolves.not.toThrow();
         expect(EndpointBalanceUtil.chooseEndpoint).toHaveBeenCalledTimes(3);
         expect(endpointArgCapture[1]).toEqual(['bean', [0], [0], null]);
         expect(endpointArgCapture[2]).toEqual(['bean', [1], [0, 1], null]);
@@ -191,7 +192,7 @@ describe('Subgraph Proxy - Core', () => {
         );
       });
 
-      await expect(SubgraphProxyService._getQueryResult('bean', 'graphql query')).rejects.toThrow(RequestError);
+      await expect(_getQueryResult()).rejects.toThrow(RequestError);
       expect(EndpointBalanceUtil.chooseEndpoint).toHaveBeenCalledTimes(1);
     });
     test('User explicitly queries far future block', async () => {
@@ -201,7 +202,7 @@ describe('Subgraph Proxy - Core', () => {
         );
       });
 
-      await expect(SubgraphProxyService._getQueryResult('bean', 'graphql query')).rejects.toThrow(RequestError);
+      await expect(_getQueryResult()).rejects.toThrow(RequestError);
       expect(EndpointBalanceUtil.chooseEndpoint).toHaveBeenCalledTimes(1);
     });
     test('User explicitly queries current block that is indexed but temporarily unavailable', async () => {
@@ -228,7 +229,7 @@ describe('Subgraph Proxy - Core', () => {
         .mockImplementationOnce((...args) => captureAndReturn(endpointArgCapture, 1, ...args))
         .mockImplementationOnce((...args) => captureAndReturn(endpointArgCapture, 0, ...args));
 
-      await expect(SubgraphProxyService._getQueryResult('bean', 'graphql query')).resolves.not.toThrow();
+      await expect(_getQueryResult()).resolves.not.toThrow();
       expect(EndpointBalanceUtil.chooseEndpoint).toHaveBeenCalledTimes(3);
       expect(endpointArgCapture[1]).toEqual(['bean', [], [0], null]);
       expect(endpointArgCapture[2]).toEqual(['bean', [], [0, 1], null]);
@@ -249,11 +250,11 @@ describe('Subgraph Proxy - Core', () => {
         .mockResolvedValueOnce(async () => beanBehindResponse)
         .mockResolvedValueOnce(async () => beanResponse);
       // Initial query that gets the latest block successfully
-      await expect(SubgraphProxyService._getQueryResult('bean', 'graphql query')).resolves.not.toThrow();
+      await expect(_getQueryResult()).resolves.not.toThrow();
       expect(EndpointBalanceUtil.chooseEndpoint).toHaveBeenCalledTimes(1);
 
       // Second query that fails to get the latest block on first 2 attempts
-      await expect(SubgraphProxyService._getQueryResult('bean', 'graphql query')).resolves.not.toThrow();
+      await expect(_getQueryResult()).resolves.not.toThrow();
       expect(EndpointBalanceUtil.chooseEndpoint).toHaveBeenCalledTimes(4);
       expect(endpointArgCapture[2]).toEqual(['bean', [], [0], null]);
       expect(endpointArgCapture[3]).toEqual(['bean', [], [0, 1], null]);
@@ -264,6 +265,6 @@ describe('Subgraph Proxy - Core', () => {
     // The initial request is rejected, no endpoints are available to service this request
     jest.spyOn(EndpointBalanceUtil, 'chooseEndpoint').mockReturnValueOnce(-1);
 
-    await expect(SubgraphProxyService._getQueryResult('bean', 'graphql query')).rejects.toThrow(RateLimitError);
+    await expect(_getQueryResult()).rejects.toThrow(RateLimitError);
   });
 });

--- a/proxy-api/test/util.test.js
+++ b/proxy-api/test/util.test.js
@@ -111,5 +111,17 @@ describe('Utils', () => {
       expect(GraphqlQueryUtil._includesVersion('version(id: "subgraph") {')).toEqual(true);
       expect(GraphqlQueryUtil._includesVersion('a  version\n(   id: \n\n"subgraph"){')).toEqual(true);
     });
+
+    test('Identifies introspection queries', () => {
+      expect(GraphqlQueryUtil.minNeededBlock(`{__schema{...}}`)).toEqual(0);
+      expect(
+        GraphqlQueryUtil.minNeededBlock(`{
+          __type
+          {...}
+        }`)
+      ).toEqual(0);
+      expect(GraphqlQueryUtil.minNeededBlock(`{beanstalks{id}}`)).toEqual(Number.MAX_SAFE_INTEGER);
+      expect(GraphqlQueryUtil.minNeededBlock(`{beanstalks{id}} {__schema{...}}`)).toEqual(0);
+    });
   });
 });

--- a/proxy-api/test/util.test.js
+++ b/proxy-api/test/util.test.js
@@ -28,7 +28,12 @@ describe('Utils', () => {
       `;
       const result = await SubgraphProxyService.handleProxyRequest('bean', query);
 
-      expect(spy).toHaveBeenCalledWith('bean', GraphqlQueryUtil.addMetadataToQuery(query), undefined);
+      expect(spy).toHaveBeenCalledWith(
+        'bean',
+        GraphqlQueryUtil.addMetadataToQuery(query),
+        undefined,
+        GraphqlQueryUtil.minNeededBlock(query)
+      );
       expect(result.meta.deployment).toEqual('QmXXZrhjqb4ygSWVgkPYBWJ7AzY4nKEUqiN5jnDopWBSCD');
       expect(result.body.beanCrosses.length).toEqual(5);
       expect(result.body._meta).toBeUndefined();
@@ -51,7 +56,12 @@ describe('Utils', () => {
       `;
       const result = await SubgraphProxyService.handleProxyRequest('bean', query);
 
-      expect(spy).toHaveBeenCalledWith('bean', GraphqlQueryUtil.addMetadataToQuery(query), undefined);
+      expect(spy).toHaveBeenCalledWith(
+        'bean',
+        GraphqlQueryUtil.addMetadataToQuery(query),
+        undefined,
+        GraphqlQueryUtil.minNeededBlock(query)
+      );
       expect(result.meta.deployment).toEqual('QmXXZrhjqb4ygSWVgkPYBWJ7AzY4nKEUqiN5jnDopWBSCD');
       expect(result.body.beanCrosses.length).toEqual(5);
       expect(result.body._meta.block.number).toEqual(responseBlock);


### PR DESCRIPTION
- Now processes a webhook alert when a subgraph goes out of sync (in practice we don't activate them initially in the .env until they are synced)
- Proxy will allow responses to introspection queries even if the underlying subgraph is not yet queryable