### PR TITLE
Misc Improvements

### DIFF
--- a/proxy-api/src/routes/subgraph-routes.js
+++ b/proxy-api/src/routes/subgraph-routes.js
@@ -17,6 +17,8 @@ router.post(':subgraphName', async (ctx) => {
   ctx.set('X-Version', proxiedResult.meta.version);
   ctx.set('X-Deployment', proxiedResult.meta.deployment);
   ctx.set('X-Chain', proxiedResult.meta.chain);
+  ctx.set('X-Indexed-Block', proxiedResult.meta.indexedBlock);
+  ctx.set('X-Endpoint', proxiedResult.meta.endpointIndex);
 
   ctx.body = {
     data: proxiedResult.body

--- a/proxy-api/src/services/subgraph-proxy-service.js
+++ b/proxy-api/src/services/subgraph-proxy-service.js
@@ -191,8 +191,8 @@ class SubgraphProxyService {
     if (matchPast) {
       // Blocks are provided in reverse order for the two endpoint types
       const blocks = [parseInt(matchPast[1]), parseInt(matchPast[2])];
-      const earliestBlock = Math.min(...blocks);
-      const requestedBlock = Math.max(...blocks);
+      const requestedBlock = Math.min(...blocks);
+      const earliestBlock = Math.max(...blocks);
       throw new RequestError(
         `The requested block ${requestedBlock} is smaller than the earliest accessible block for ${subgraphName}: ${earliestBlock}.`
       );

--- a/proxy-api/src/services/subgraph-proxy-service.js
+++ b/proxy-api/src/services/subgraph-proxy-service.js
@@ -126,6 +126,12 @@ class SubgraphProxyService {
         }
 
         if (queryResult._meta.block.number >= SubgraphState.getLatestBlock(subgraphName)) {
+          if (errors.length > 0) {
+            // If there were any errors before an accepted response, log them
+            console.log(
+              `Accepted request, but one endpoint failed with message: ${errors[0].message}\nquery: ${query}`
+            );
+          }
           stepRecorder.accepted(endpointIndex);
           return {
             data: queryResult,

--- a/proxy-api/src/services/subgraph-proxy-service.js
+++ b/proxy-api/src/services/subgraph-proxy-service.js
@@ -50,10 +50,10 @@ class SubgraphProxyService {
     const endpointHistory = new EndpointHistory();
     try {
       const result = await this._getReliableResult(subgraphName, query, variables, requiredBlock, endpointHistory);
-      LoggingUtil.logSuccessfulProxy(subgraphName, startTime, startUtilization, endpointHistory);
+      LoggingUtil.logSuccessfulProxy(query, subgraphName, startTime, startUtilization, endpointHistory);
       return result;
     } catch (e) {
-      LoggingUtil.logFailedProxy(subgraphName, startTime, startUtilization, endpointHistory);
+      LoggingUtil.logFailedProxy(query, subgraphName, startTime, startUtilization, endpointHistory);
       throw e;
     }
   }

--- a/proxy-api/src/utils/graph-query.js
+++ b/proxy-api/src/utils/graph-query.js
@@ -68,17 +68,22 @@ class GraphqlQueryUtil {
     return Math.max(...blocks);
   }
 
-  // Returns true if this query uses the time travel feature (i.e. explicit block)
-  static usesTimeTravel(originalQuery) {
-    // TODO
+  // Returns a string representing the various features used in this query
+  static queryFeaturesString(query) {
+    let features = '';
+    features += /\([^\(\)]*where[^\(\)]*\)/.test(query) ? 'whr' : '   ';
+    features += /\([^\(\)]*block\s*:\s*\{\s*number(?:_gte)?\s*:\s*\d+\s*\}[^\(\)]*\)/.test(query) ? 'blk' : '   ';
+    features += /\([^\(\)]*orderBy[^\(\)]*\)/.test(query) ? 'srt' : '   ';
+    features += /\([^\(\)]*skip[^\(\)]*\)/.test(query) ? 'skp' : '   ';
+    return features;
   }
 
-  static _includesMeta(originalQuery) {
-    return /_meta\s*\{/.test(originalQuery);
+  static _includesMeta(query) {
+    return /_meta\s*\{/.test(query);
   }
 
-  static _includesVersion(originalQuery) {
-    return /version\s*\(\s*id\s*:\s*"subgraph"\s*\)\s*\{/.test(originalQuery);
+  static _includesVersion(query) {
+    return /version\s*\(\s*id\s*:\s*"subgraph"\s*\)\s*\{/.test(query);
   }
 }
 

--- a/proxy-api/src/utils/graph-query.js
+++ b/proxy-api/src/utils/graph-query.js
@@ -56,6 +56,7 @@ class GraphqlQueryUtil {
         }
         return `(${Number.MAX_SAFE_INTEGER})`;
       })
+      .replace(/_meta\s*{/, `_meta(0) {`)
       .replace(/(\w+)\s*{/, `$1(${Number.MAX_SAFE_INTEGER}) {`);
 
     // Remove everything between all remaining {}

--- a/proxy-api/src/utils/load/bottleneck-limiters.js
+++ b/proxy-api/src/utils/load/bottleneck-limiters.js
@@ -22,6 +22,9 @@ class BottleneckLimiters {
           reservoirIncreaseInterval: interval,
           reservoirIncreaseMaximum: maxBurst,
           maxConcurrent: maxBurst,
+          // An ideal implementation would involve two limiters: a burst limiter and a throttle limiter.
+          // The burst limiter would have no minTime as it would allow for making many concurrent requests
+          // when there is initially no traffic. Not necessary to implement at this time.
           minTime: Math.ceil(interval / rqPerInterval)
         })
       );

--- a/proxy-api/src/utils/logging.js
+++ b/proxy-api/src/utils/logging.js
@@ -1,13 +1,15 @@
+const GraphqlQueryUtil = require('./graph-query');
 const EndpointBalanceUtil = require('./load/endpoint-balance');
 
 class LoggingUtil {
   // Used to determine how much whitespace should pad the start of the subgraph name
   static longestEncounteredName = 0;
 
-  static async logSuccessfulProxy(subgraphName, startTime, startUtilization, endpointHistory) {
+  static async logSuccessfulProxy(query, subgraphName, startTime, startUtilization, endpointHistory) {
     console.log(
       await this._formatLog(
         '[success]',
+        query,
         subgraphName,
         startTime,
         startUtilization,
@@ -18,10 +20,11 @@ class LoggingUtil {
     );
   }
 
-  static async logFailedProxy(subgraphName, startTime, startUtilization, endpointHistory) {
+  static async logFailedProxy(query, subgraphName, startTime, startUtilization, endpointHistory) {
     console.log(
       await this._formatLog(
         '<failure>',
+        query,
         subgraphName,
         startTime,
         startUtilization,
@@ -37,6 +40,7 @@ class LoggingUtil {
   // 2024-08-24T01:17:41.354Z <failure>: basin---------- ------ after  141ms | Steps: 0 | Load: e-0: 33%
   static async _formatLog(
     type,
+    query,
     subgraphName,
     startTime,
     startUtilization,
@@ -49,6 +53,7 @@ class LoggingUtil {
     }
     const toEndpoint = usedEndpoint !== undefined ? `to e-${usedEndpoint.index} ` : ' ';
 
+    const queryFeatures = GraphqlQueryUtil.queryFeaturesString(query).padEnd(12);
     const timeElapsed = `${new Date() - startTime}ms`.padStart(6);
     const subgraphAndTime =
       `${subgraphName.padEnd(this.longestEncounteredName, '-')} ${`${toEndpoint}after ${timeElapsed}`.padStart(19, '-')}`.padEnd(
@@ -58,7 +63,7 @@ class LoggingUtil {
     const blacklistStrs = blacklist.map((e) => `${e.index}${e.reason}`);
     const steps = (`Steps[${blacklistStrs.join(',')}]`.padEnd(10) + `: ${historyStrs.join(',')}`).padEnd(40);
     const utilization = `Load: ${this._formatUtilizationString(startUtilization)}`;
-    return `${new Date().toISOString()} ${type}: ${subgraphAndTime} | ${steps} | ${utilization}`;
+    return `${new Date().toISOString()} ${type}: ${subgraphAndTime} | ${steps} | ${queryFeatures} | ${utilization}`;
   }
 
   static _formatUtilizationString(utilization) {

--- a/proxy-api/test/jest.setup.js
+++ b/proxy-api/test/jest.setup.js
@@ -28,3 +28,5 @@ jest.mock('../src/datasources/evm-providers', () => {
 jest.mock('../src/utils/discord');
 // Disable LoggingUtil logs
 jest.mock('../src/utils/logging');
+
+console.log = () => {};

--- a/proxy-api/test/proxy-internals.test.js
+++ b/proxy-api/test/proxy-internals.test.js
@@ -160,7 +160,7 @@ describe('Subgraph Proxy - Core', () => {
         await expect(_getQueryResult(newDeploymentBlock)).resolves.not.toThrow();
 
         expect(EndpointBalanceUtil.chooseEndpoint).toHaveBeenCalledTimes(1);
-        expect(endpointArgCapture[0]).toEqual(['bean', [], [], null]);
+        expect(endpointArgCapture[0]).toEqual(['bean', [], [], newDeploymentBlock]);
       });
     });
     describe('Old subgraph version is not accepted', () => {

--- a/proxy-api/test/util.test.js
+++ b/proxy-api/test/util.test.js
@@ -153,4 +153,40 @@ describe('Utils', () => {
       });
     });
   });
+
+  test('Identifies query features', () => {
+    const features1 = GraphqlQueryUtil.queryFeaturesString(`
+        {
+          well(
+            id: "0x3e1133aC082716DDC3114bbEFEeD8B1731eA9cb1"
+            block: {number: 24622961}
+          )
+        }`);
+    expect(['blk'].every((str) => features1.includes(str))).toBeTruthy();
+
+    const features2 = GraphqlQueryUtil.queryFeaturesString(`
+        {
+          wells(
+            where: {field: value}
+            orderBy: field
+            orderDirection: asc
+          )
+        }`);
+    expect(['whr', 'srt'].every((str) => features2.includes(str))).toBeTruthy();
+
+    const features3 = GraphqlQueryUtil.queryFeaturesString(`
+      {
+        wells(
+          skip: 50
+          block: {number: 24622961}
+        )
+      }`);
+    expect(['blk', 'skp'].every((str) => features3.includes(str))).toBeTruthy();
+
+    const noFeatures = GraphqlQueryUtil.queryFeaturesString(`
+      {
+        wells() { id }
+      }`);
+    expect(['whr', 'blk', 'srt', 'skp'].every((str) => !noFeatures.includes(str))).toBeTruthy();
+  });
 });

--- a/proxy-api/test/util.test.js
+++ b/proxy-api/test/util.test.js
@@ -18,7 +18,9 @@ describe('Utils', () => {
 
   describe('Query manipulation tests', () => {
     test('Add and removes extra metadata from request/response', async () => {
-      const spy = jest.spyOn(SubgraphProxyService, '_getQueryResult').mockResolvedValueOnce(beanResponse);
+      const spy = jest
+        .spyOn(SubgraphProxyService, '_getQueryResult')
+        .mockResolvedValueOnce({ data: beanResponse, endpointIndex: 0 });
       const query = gql`
         {
           beanCrosses(first: 5) {
@@ -41,7 +43,9 @@ describe('Utils', () => {
     });
 
     test('Does not remove explicitly requested metadata', async () => {
-      const spy = jest.spyOn(SubgraphProxyService, '_getQueryResult').mockResolvedValueOnce(beanResponse);
+      const spy = jest
+        .spyOn(SubgraphProxyService, '_getQueryResult')
+        .mockResolvedValueOnce({ data: beanResponse, endpointIndex: 0 });
       const query = gql`
         {
           _meta {

--- a/proxy-api/test/util.test.js
+++ b/proxy-api/test/util.test.js
@@ -121,6 +121,38 @@ describe('Utils', () => {
         ).toBe(24622961);
       });
 
+      test('Always allows _meta entity', () => {
+        expect(
+          GraphqlQueryUtil.requiredIndexedBlock(`
+          {
+            _meta {
+              block {
+                number
+              }
+            }
+          }
+          `)
+        ).toBe(0);
+
+        expect(
+          GraphqlQueryUtil.requiredIndexedBlock(`
+          {
+            _meta {
+              block {
+                number
+              }
+            }
+            top(block: {number: 123}) {
+              id
+              nested(where: test) {
+                id
+              }
+            }
+          }
+          `)
+        ).toBe(123);
+      });
+
       test('Works with nested entity access', () => {
         expect(
           GraphqlQueryUtil.requiredIndexedBlock(`


### PR DESCRIPTION
- Allows querying blocks which have been indexed even when the subgraph isn't fully caught up
- Includes latest indexed block and underlying endpoint id in response headers
- Adds query feature list to the logs
- Logs failure reason if one endpoint fails and the other accepts